### PR TITLE
h2 compatibility: getId not autoconverts ints.  

### DIFF
--- a/src/ez/Row.java
+++ b/src/ez/Row.java
@@ -34,7 +34,8 @@ public class Row implements Iterable<String> {
   }
 
   public Long getId() {
-    return getLong("id");
+    Object val = map.get("id");
+    return (val instanceof Long) ? (Long) val : ((Integer) val).longValue();
   }
 
   public String get(String key) {


### PR DESCRIPTION
Needed for ENDER-641.  H2 (in memory database) regards unsigned ints in such a way that, when those rows are pulled out of the database, the id column is an int rather than a long.  This fixes that.  