### PR TITLE
Add ability to parse `Instant` out of a date string.

### DIFF
--- a/src/ez/Row.java
+++ b/src/ez/Row.java
@@ -2,6 +2,7 @@ package ez;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collection;
@@ -88,6 +89,11 @@ public class Row implements Iterable<String> {
   public LocalDateTime getDateTime(String key) {
     String s = (String) map.get(key);
     return LocalDateTime.parse(s);
+  }
+
+  public Instant getInstant(String key) {
+    String s = (String) map.get(key);
+    return Instant.parse(key);
   }
 
   public byte[] getBlob(String key) {


### PR DESCRIPTION
This is useful because the existing methods allow you to parse a `LocalDateTime` only. This class requires extra information about zone or offset to be able to precisely identify a moment in time. Using `Instant` is a much better approach, and works regardless of JVM or OS time zone settings, handles DST etc.