### PR TITLE
Use catalog instead of schema for PSQL connection URL

### DIFF
--- a/src/ez/DB.java
+++ b/src/ez/DB.java
@@ -164,7 +164,8 @@ public abstract class DB {
     String type = databaseType == DatabaseType.POSTGRES ? "postgresql" : "mysql";
     int port = databaseType == DatabaseType.POSTGRES ? 5432 : 3306;
 
-    String url = format("{0}://{1}:{2}/{3}", type, host, port, schema);
+    String url = format("{0}://{1}:{2}/{3}", type, host, port,
+        (databaseType == DatabaseType.POSTGRES) ? catalog : schema);
 
     if (databaseType == DatabaseType.MYSQL) {
       if (ssl) {


### PR DESCRIPTION
### Description
The current code creates PSQL connections with `schema` as the DB name. However, since it's fixed to "public", the connection is certain to fail. (Except there happens to be a DB named as "public".) This PR corrects the DB name.

### Test
Ran MLS related queries in Ender App and now the following exception is fixed -

```
2024-04-22T23:55:14.254920Z 01HW43RBSSVT676VMXG48AC5XZ java.lang.RuntimeException: Problem handling API request: POST /markets/summaryStats
 (...)
Caused by: java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at ender.web.misc.EnderController.lambda$createRoute$6(EnderController.java:77)
	... 12 more
Caused by: java.lang.RuntimeException: Problem connecting to jdbc:postgresql://mls.ender.com:5432/public
	at ez.DB.getConnection(DB.java:851)
	at ez.DB.getConnection(DB.java:823)
	at ez.RowSelector.select(RowSelector.java:32)
	at ez.RowSelector.stream(RowSelector.java:79)
	at ez.DB.stream(DB.java:380)
	at ez.DB.stream(DB.java:374)
	at ez.DB.stream(DB.java:370)
	at com.ender.buy.db.misc.RawMLSListingDB.getNumberOfHomesPerCBSA(RawMLSListingDB.java:63)
	at com.ender.buy.api.MarketsAPI.getMarketSummaryStats(MarketsAPI.java:94)
	... 17 more
Caused by: org.postgresql.util.PSQLException: FATAL: database "public" does not exist
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2676)
	at org.postgresql.core.v3.QueryExecutorImpl.readStartupMessages(QueryExecutorImpl.java:2788)
	at org.postgresql.core.v3.QueryExecutorImpl.<init>(QueryExecutorImpl.java:174)
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:290)
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:49)
	at org.postgresql.jdbc.PgConnection.<init>(PgConnection.java:247)
	at org.postgresql.Driver.makeConnection(Driver.java:434)
	at org.postgresql.Driver.connect(Driver.java:291)
	at com.zaxxer.hikari.util.DriverDataSource.getConnection(DriverDataSource.java:138)
	at com.zaxxer.hikari.pool.PoolBase.newConnection(PoolBase.java:359)
	at com.zaxxer.hikari.pool.PoolBase.newPoolEntry(PoolBase.java:201)
	at com.zaxxer.hikari.pool.HikariPool.createPoolEntry(HikariPool.java:470)
	at com.zaxxer.hikari.pool.HikariPool.checkFailFast(HikariPool.java:561)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:100)
	at com.zaxxer.hikari.HikariDataSource.getConnection(HikariDataSource.java:112)
	at ez.DB.getConnection(DB.java:847)
	... 25 more
```